### PR TITLE
Added babel rc to ignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ tools/
 .gitignore
 .travis.yml
 karma.conf.js
+.babelrc


### PR DESCRIPTION
The babelrc file is causing build problems if babel 6 is used in the host project. 

See the following discussion for more context:

https://github.com/facebook/react-native/issues/4062

