### PR TITLE
Move babel-runtime to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-core": "~5.8.22",
     "babel-eslint": "~4.1.3",
     "babel-loader": "~5.3.2",
+    "babel-runtime": "^5.8.0",
     "chai": "~3.3.0",
     "child-process-promise": "~1.1.0",
     "colors": "~1.1.0",
@@ -54,7 +55,7 @@
     "release-script": "^0.5.3",
     "webpack": "~1.12.2"
   },
-  "dependencies": {
-    "babel-runtime": "^5.8.0"
+  "peerDependencies": {
+    "babel-runtime": ">=5.8.0"
   }
 }


### PR DESCRIPTION
Not sure if `>= 5.8.0` is too lenient ¯\_(ツ)_/¯

I kept it in the devDependencies to make sure it's there for local development.

What do you think @dozoisch ?