### PR TITLE
Add option (removeOnUnmount) to delete/remove tag script on component unmount

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The api is very simple `makeAsyncScriptLoader(Component, scriptUrl, options)`. W
     - exposeFuncs: Array of String. It'll create a function that will call the child component with the same name. It passes arguments and return value.
     - callbackName: If the scripts calls a global function when loaded, provide the callback name here. It'll be autoregistered on the window.
     - globalName: If wanted, provide the globalName of the loaded script. It'll be injected on the component with the same name *(ex: "grecaptcha")*
+    - removeOnUnmount: Boolean **default=false**: If set to true removes the script tag on the component unmount
 
 You can retrieve the child component using the fonction called `getComponent()`.
 

--- a/test/async-script-loader-spec.js
+++ b/test/async-script-loader-spec.js
@@ -16,6 +16,16 @@ const MockedComponent = React.createClass({
   },
 });
 
+const hasScript = () => {
+  let as=document.getElementsByTagName("script");
+  for(let i = 0; i < as.length; i+=1) {
+    if (as[i].src.indexOf("http://example.com") > -1) {
+      return true;          
+    }
+  }
+  return false;
+}
+
 describe("AsyncScriptLoader", () => {
   it("should be imported successfully", () => {
     assert.isNotNull(makeAsyncScriptLoader);
@@ -50,5 +60,25 @@ describe("AsyncScriptLoader", () => {
       <ComponentWrapper />
     );
     instance.callsACallback(done);
+  });
+  it("should not remove tag script on removeOnUnmount option not set", () => { 
+    let ComponentWrapper = makeAsyncScriptLoader(MockedComponent, "http://example.com");
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ComponentWrapper />
+    );
+    assert.equal(hasScript(), true);
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance));
+    instance.componentWillUnmount();
+    assert.equal(hasScript(), true);
+  });
+  it("should remove tag script on removeOnUnmount option set to true", () => { 
+    let ComponentWrapper = makeAsyncScriptLoader(MockedComponent, "http://example.com", { removeOnUnmount: true });
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ComponentWrapper />
+    );
+    assert.equal(hasScript(), true);
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance));
+    instance.componentWillUnmount();
+    assert.equal(hasScript(), false);
   });
 });


### PR DESCRIPTION
#### Motivation

On a SPA use of 3rd party scripts that need to be loaded several times on different access to a route; the script must unloaded first to be able to be loaded again.

