### PR TITLE
Issue with this being undefined in asyncScriptLoaderHandleLoad

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-async-script",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A composition mixin for loading scripts asynchronously for React",
   "main": "lib/async-script-loader.js",
   "scripts": {

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -40,12 +40,12 @@ export default function makeAsyncScript(Component, scriptURL, options) {
           this.asyncScriptLoaderHandleLoad(entry);
           return;
         }
-        entry.observers.set(key, this.asyncScriptLoaderHandleLoad);
+        entry.observers.set(key, (entry) => this.asyncScriptLoaderHandleLoad(entry));
         return;
       }
 
       let observers = new Map();
-      observers.set(key, this.asyncScriptLoaderHandleLoad);
+      observers.set(key, (entry) => this.asyncScriptLoaderHandleLoad(entry));
       SCRIPT_MAP.set(scriptURL, {
         loaded: false,
         observers: observers,


### PR DESCRIPTION
I was getting the following error on trying to load google recaptcha (using react-google-recaptcha):
`cannot read property 'setState' of undefined at asyncScriptLoaderHandleLoader`

I fixed this by wrapping the function calls to that function in a function.