### PR TITLE
remove transform runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,5 @@
     "react",
     [ "es2015", { "loose": true } ]
   ],
-  "plugins": [ "transform-runtime", "transform-object-rest-spread" ]
+  "plugins": [ "transform-object-rest-spread" ]
 }


### PR DESCRIPTION
follow up to #28 , paired with https://github.com/dozoisch/react-google-recaptcha/pull/87

- removes `transform-runtime` to remove all polyfills

I created an example repo here [test-build-webpack-babel-transform-runtime](https://github.com/hartzis/test-build-webpack-babel-transform-runtime) that runs a webpack bundle on a `react-google-recaptcha` component that includes `react-async-script`.

Simple entry point:
```
import react from 'react';
import ReCAPTCHA from 'react-google-recaptcha';

function Test() {
  return (<ReCAPTCHA />)
}
```

I ran a reports *with* and **without** `transform-runtime`:
- **with** `transform-runtime` | [report-transform-runtime.html](https://hartzis.github.io/test-build-webpack-babel-transform-runtime/report-transform-runtime.html)
  - has ~ `17kb parsed / 6kb gzip` worth of `babel-runtime/core-js` polyfills
- **without** `transform-runtime` | [report-**no**-transform-runtime](https://hartzis.github.io/test-build-webpack-babel-transform-runtime/report-no-transform-runtime.html)
  - has some included helpers at the top of each ~`1kb parsed / 0.3kb gzip` added to each package

### Screenshots
With:
<img width="1417" alt="screen shot 2018-07-27 at 10 41 00 pm" src="https://user-images.githubusercontent.com/5378707/43353151-4447659a-91ee-11e8-8f16-64e11a48421f.png">

Without:
<img width="1357" alt="screen shot 2018-07-27 at 10 41 28 pm" src="https://user-images.githubusercontent.com/5378707/43353153-4e34ddf8-91ee-11e8-8440-4a987ddf22be.png">
