### PR TITLE
remove babel-runtime peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "webpack": "~1.14.0"
   },
   "peerDependencies": {
-    "babel-runtime": ">=5.8.0",
     "react": ">=15.5.0"
   },
   "dependencies": {


### PR DESCRIPTION
- remove un-needed babel-runtime peer dep
- closes #25 