### PR TITLE
Hoc pattern, test fixes and clean-ups

### DIFF
--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -13,8 +13,8 @@ export default function makeAsyncScript(getScriptURL, options) {
     WrappedComponent.displayName || WrappedComponent.name || "Component";
 
     class AsyncScriptLoader extends Component {
-      constructor() {
-        super();
+      constructor(props, context) {
+        super(props, context)
         this.state = {};
         this.__scriptURL = "";
         this.assignChildComponent = this.assignChildComponent.bind(this);

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -42,8 +42,10 @@ export default function makeAsyncScript(getScriptURL, options) {
       }
 
       asyncScriptLoaderHandleLoad(state) {
-        // use reacts setState callback to fire asyncScriptOnLoad
-        this.setState(state, this.props.asyncScriptOnLoad);
+        // use reacts setState callback to fire props.asyncScriptOnLoad with new state/entry
+        this.setState(state,
+          () => this.props.asyncScriptOnLoad && this.props.asyncScriptOnLoad(this.state)
+        );
       }
 
       asyncScriptLoaderTriggerOnScriptLoaded() {

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -141,19 +141,6 @@ export default function makeAsyncScript(getScriptURL, options) {
           }
         };
 
-        // (old) MSIE browsers may call "onreadystatechange" instead of "onload"
-        script.onreadystatechange = () => {
-          if (this.readyState === "loaded") {
-            // wait for other events, then call onload if default onload hadn't been called
-            window.setTimeout(() => {
-              const mapEntry = SCRIPT_MAP[scriptURL];
-              if (mapEntry && mapEntry.loaded !== true) {
-                script.onload();
-              }
-            }, 0);
-          }
-        };
-
         document.body.appendChild(script);
       }
 

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component, createElement } from "react";
 import PropTypes from "prop-types";
 
 let SCRIPT_MAP = {};
@@ -6,192 +6,193 @@ let SCRIPT_MAP = {};
 // A counter used to generate a unique id for each component that uses the function
 let idCount = 0;
 
-export default function makeAsyncScript(Component, getScriptURL, options) {
+export default function makeAsyncScript(getScriptURL, options) {
   options = options || {};
-  const wrappedComponentName =
-    Component.displayName || Component.name || "Component";
+  return function wrapWithAsyncScript(WrappedComponent) {
+    const wrappedComponentName =
+    WrappedComponent.displayName || WrappedComponent.name || "Component";
 
-  class AsyncScriptLoader extends React.Component {
-    constructor() {
-      super();
-      this.state = {};
-      this.__scriptURL = "";
-    }
-
-    asyncScriptLoaderGetScriptLoaderID() {
-      if (!this.__scriptLoaderID) {
-        this.__scriptLoaderID = "async-script-loader-" + idCount++;
-      }
-      return this.__scriptLoaderID;
-    }
-
-    setupScriptURL() {
-      this.__scriptURL =
-        typeof getScriptURL === "function" ? getScriptURL() : getScriptURL;
-      return this.__scriptURL;
-    }
-
-    getComponent() {
-      return this.__childComponent;
-    }
-
-    asyncScriptLoaderHandleLoad(state) {
-      this.setState(state, this.props.asyncScriptOnLoad);
-    }
-
-    asyncScriptLoaderTriggerOnScriptLoaded() {
-      let mapEntry = SCRIPT_MAP[this.__scriptURL];
-      if (!mapEntry || !mapEntry.loaded) {
-        throw new Error("Script is not loaded.");
-      }
-      for (let obsKey in mapEntry.observers) {
-        mapEntry.observers[obsKey](mapEntry);
-      }
-      delete window[options.callbackName];
-    }
-
-    componentDidMount() {
-      const scriptURL = this.setupScriptURL();
-      const key = this.asyncScriptLoaderGetScriptLoaderID();
-      const { globalName, callbackName } = options;
-      if (globalName && typeof window[globalName] !== "undefined") {
-        SCRIPT_MAP[scriptURL] = { loaded: true, observers: {} };
+    class AsyncScriptLoader extends Component {
+      constructor() {
+        super();
+        this.state = {};
+        this.__scriptURL = "";
+        this.assignChildComponent = this.assignChildComponent.bind(this);
       }
 
-      if (SCRIPT_MAP[scriptURL]) {
-        let entry = SCRIPT_MAP[scriptURL];
-        if (entry && (entry.loaded || entry.errored)) {
-          this.asyncScriptLoaderHandleLoad(entry);
+      asyncScriptLoaderGetScriptLoaderID() {
+        if (!this.__scriptLoaderID) {
+          this.__scriptLoaderID = "async-script-loader-" + idCount++;
+        }
+        return this.__scriptLoaderID;
+      }
+
+      setupScriptURL() {
+        this.__scriptURL =
+          typeof getScriptURL === "function" ? getScriptURL() : getScriptURL;
+        return this.__scriptURL;
+      }
+
+      assignChildComponent(ref) {
+        this.__childComponent = ref;
+      }
+
+      getComponent() {
+        return this.__childComponent;
+      }
+
+      asyncScriptLoaderHandleLoad(state) {
+        this.setState(state, this.props.asyncScriptOnLoad);
+      }
+
+      asyncScriptLoaderTriggerOnScriptLoaded() {
+        let mapEntry = SCRIPT_MAP[this.__scriptURL];
+        if (!mapEntry || !mapEntry.loaded) {
+          throw new Error("Script is not loaded.");
+        }
+        for (let obsKey in mapEntry.observers) {
+          mapEntry.observers[obsKey](mapEntry);
+        }
+        delete window[options.callbackName];
+      }
+
+      componentDidMount() {
+        const scriptURL = this.setupScriptURL();
+        const key = this.asyncScriptLoaderGetScriptLoaderID();
+        const { globalName, callbackName } = options;
+        if (globalName && typeof window[globalName] !== "undefined") {
+          SCRIPT_MAP[scriptURL] = { loaded: true, observers: {} };
+        }
+
+        if (SCRIPT_MAP[scriptURL]) {
+          let entry = SCRIPT_MAP[scriptURL];
+          if (entry && (entry.loaded || entry.errored)) {
+            this.asyncScriptLoaderHandleLoad(entry);
+            return;
+          }
+          entry.observers[key] = entry => this.asyncScriptLoaderHandleLoad(entry);
           return;
         }
-        entry.observers[key] = entry => this.asyncScriptLoaderHandleLoad(entry);
-        return;
-      }
 
-      let observers = {};
-      observers[key] = entry => this.asyncScriptLoaderHandleLoad(entry);
-      SCRIPT_MAP[scriptURL] = {
-        loaded: false,
-        observers,
-      };
+        let observers = {};
+        observers[key] = entry => this.asyncScriptLoaderHandleLoad(entry);
+        SCRIPT_MAP[scriptURL] = {
+          loaded: false,
+          observers,
+        };
 
-      let script = document.createElement("script");
+        let script = document.createElement("script");
 
-      script.src = scriptURL;
-      script.async = true;
+        script.src = scriptURL;
+        script.async = true;
 
-      let callObserverFuncAndRemoveObserver = func => {
-        if (SCRIPT_MAP[scriptURL]) {
+        let callObserverFuncAndRemoveObserver = func => {
+          if (SCRIPT_MAP[scriptURL]) {
+            let mapEntry = SCRIPT_MAP[scriptURL];
+            let observersMap = mapEntry.observers;
+
+            for (let obsKey in observersMap) {
+              if (func(observersMap[obsKey])) {
+                delete observersMap[obsKey];
+              }
+            }
+          }
+        };
+
+        if (callbackName && typeof window !== "undefined") {
+          window[callbackName] = () =>
+            this.asyncScriptLoaderTriggerOnScriptLoaded();
+        }
+
+        script.onload = () => {
           let mapEntry = SCRIPT_MAP[scriptURL];
-          let observersMap = mapEntry.observers;
-
-          for (let obsKey in observersMap) {
-            if (func(observersMap[obsKey])) {
-              delete observersMap[obsKey];
-            }
+          if (mapEntry) {
+            mapEntry.loaded = true;
+            callObserverFuncAndRemoveObserver(observer => {
+              if (callbackName) {
+                return false;
+              }
+              observer(mapEntry);
+              return true;
+            });
           }
-        }
-      };
+        };
+        script.onerror = event => {
+          let mapEntry = SCRIPT_MAP[scriptURL];
+          if (mapEntry) {
+            mapEntry.errored = true;
+            callObserverFuncAndRemoveObserver(observer => {
+              observer(mapEntry);
+              return true;
+            });
+          }
+        };
 
-      if (callbackName && typeof window !== "undefined") {
-        window[callbackName] = () =>
-          this.asyncScriptLoaderTriggerOnScriptLoaded();
+        // (old) MSIE browsers may call "onreadystatechange" instead of "onload"
+        script.onreadystatechange = () => {
+          if (this.readyState === "loaded") {
+            // wait for other events, then call onload if default onload hadn't been called
+            window.setTimeout(() => {
+              const mapEntry = SCRIPT_MAP[scriptURL];
+              if (mapEntry && mapEntry.loaded !== true) {
+                script.onload();
+              }
+            }, 0);
+          }
+        };
+
+        document.body.appendChild(script);
       }
 
-      script.onload = () => {
-        let mapEntry = SCRIPT_MAP[scriptURL];
-        if (mapEntry) {
-          mapEntry.loaded = true;
-          callObserverFuncAndRemoveObserver(observer => {
-            if (callbackName) {
-              return false;
-            }
-            observer(mapEntry);
-            return true;
-          });
-        }
-      };
-      script.onerror = event => {
-        let mapEntry = SCRIPT_MAP[scriptURL];
-        if (mapEntry) {
-          mapEntry.errored = true;
-          callObserverFuncAndRemoveObserver(observer => {
-            observer(mapEntry);
-            return true;
-          });
-        }
-      };
-
-      // (old) MSIE browsers may call "onreadystatechange" instead of "onload"
-      script.onreadystatechange = () => {
-        if (this.readyState === "loaded") {
-          // wait for other events, then call onload if default onload hadn't been called
-          window.setTimeout(() => {
-            const mapEntry = SCRIPT_MAP[scriptURL];
-            if (mapEntry && mapEntry.loaded !== true) {
-              script.onload();
-            }
-          }, 0);
-        }
-      };
-
-      document.body.appendChild(script);
-    }
-
-    componentWillUnmount() {
-      // Remove tag script
-      const scriptURL = this.__scriptURL;
-      if (options.removeOnUnmount === true) {
-        const allScripts = document.getElementsByTagName("script");
-        for (let i = 0; i < allScripts.length; i += 1) {
-          if (allScripts[i].src.indexOf(scriptURL) > -1) {
-            if (allScripts[i].parentNode) {
-              allScripts[i].parentNode.removeChild(allScripts[i]);
-            }
-          }
-        }
-      }
-      // Clean the observer entry
-      let mapEntry = SCRIPT_MAP[scriptURL];
-      if (mapEntry) {
-        delete mapEntry.observers[this.asyncScriptLoaderGetScriptLoaderID()];
+      componentWillUnmount() {
+        // Remove tag script
+        const scriptURL = this.__scriptURL;
         if (options.removeOnUnmount === true) {
-          delete SCRIPT_MAP[scriptURL];
+          const allScripts = document.getElementsByTagName("script");
+          for (let i = 0; i < allScripts.length; i += 1) {
+            if (allScripts[i].src.indexOf(scriptURL) > -1) {
+              if (allScripts[i].parentNode) {
+                allScripts[i].parentNode.removeChild(allScripts[i]);
+              }
+            }
+          }
+        }
+        // Clean the observer entry
+        let mapEntry = SCRIPT_MAP[scriptURL];
+        if (mapEntry) {
+          delete mapEntry.observers[this.asyncScriptLoaderGetScriptLoaderID()];
+          if (options.removeOnUnmount === true) {
+            delete SCRIPT_MAP[scriptURL];
+          }
         }
       }
-    }
 
-    render() {
-      const globalName = options.globalName;
-      // remove asyncScriptOnLoad from childprops
-      let { asyncScriptOnLoad, ...childProps } = this.props;
-      if (globalName && typeof window !== "undefined") {
-        childProps[globalName] =
-          typeof window[globalName] !== "undefined"
-            ? window[globalName]
-            : undefined;
+      render() {
+        const globalName = options.globalName;
+        // remove asyncScriptOnLoad from childProps
+        let { asyncScriptOnLoad, ...childProps } = this.props; // eslint-disable-line no-unused-vars
+        if (globalName && typeof window !== "undefined") {
+          childProps[globalName] =
+            typeof window[globalName] !== "undefined"
+              ? window[globalName]
+              : undefined;
+        }
+        childProps.ref = this.assignChildComponent;
+        return createElement(WrappedComponent, childProps);
       }
-      return (
-        <Component
-          ref={comp => {
-            this.__childComponent = comp;
-          }}
-          {...childProps}
-        />
-      );
     }
-  }
-  AsyncScriptLoader.displayName = `AsyncScriptLoader(${wrappedComponentName})`;
-  AsyncScriptLoader.propTypes = {
-    asyncScriptOnLoad: PropTypes.func,
-  };
+    AsyncScriptLoader.displayName = `AsyncScriptLoader(${wrappedComponentName})`;
+    AsyncScriptLoader.propTypes = {
+      asyncScriptOnLoad: PropTypes.func,
+    };
 
-  if (options.exposeFuncs) {
-    options.exposeFuncs.forEach(funcToExpose => {
-      AsyncScriptLoader.prototype[funcToExpose] = function() {
-        return this.getComponent()[funcToExpose](...arguments);
-      };
-    });
+    if (options.exposeFuncs) {
+      options.exposeFuncs.forEach(funcToExpose => {
+        AsyncScriptLoader.prototype[funcToExpose] = function() {
+          return this.getComponent()[funcToExpose](...arguments);
+        };
+      });
+    }
+    return AsyncScriptLoader;
   }
-  return AsyncScriptLoader;
 }

--- a/test/async-script-loader-spec.js
+++ b/test/async-script-loader-spec.js
@@ -14,14 +14,26 @@ class MockedComponent extends React.Component {
   }
 }
 
-const hasScript = (URL) => {
+const getScript = (URL, toBoolean = false) => {
   const scripTags = document.getElementsByTagName("script");
   for (let i = 0; i < scripTags.length; i += 1) {
     if (scripTags[i].src.indexOf(URL) > -1) {
-      return true;
+      return toBoolean ? true : scripTags[i];
     }
   }
-  return false;
+  return toBoolean ? false : undefined;
+}
+
+const hasScript = (URL) => getScript(URL, true)
+
+const documentLoadScript = (URL) => {
+  const script = getScript(URL);
+  script.onload();
+}
+
+const documentErrorScript = (URL) => {
+  const script = getScript(URL);
+  script.onerror();
 }
 
 describe("AsyncScriptLoader", () => {
@@ -29,27 +41,69 @@ describe("AsyncScriptLoader", () => {
     assert.isNotNull(makeAsyncScriptLoader);
   });
 
-  it("should return a component that contains the passed component", () => {
-    const URL = "http://example.com";
+  it("should return a component that contains the passed component and fire asyncScriptOnLoad", () => {
+    const URL = "http://example.com/?default=true";
+    let asyncScriptOnLoadCalled = false;
+    let scriptErrored = false;
+    let scriptLoaded = false;
+    const asyncScriptOnLoadSpy = (entry) => {
+      scriptLoaded = entry.loaded;
+      scriptErrored = entry.errored;
+      asyncScriptOnLoadCalled = true;
+    }
     const ComponentWrapper = makeAsyncScriptLoader(URL)(MockedComponent);
     assert.equal(ComponentWrapper.displayName, "AsyncScriptLoader(MockedComponent)");
     const instance = ReactTestUtils.renderIntoDocument(
-      <ComponentWrapper />
+      <ComponentWrapper asyncScriptOnLoad={asyncScriptOnLoadSpy} />
     );
+    documentLoadScript(URL);
+
     assert.ok(ReactTestUtils.isCompositeComponent(instance));
     assert.ok(ReactTestUtils.isCompositeComponentWithType(instance, ComponentWrapper));
     assert.isNotNull(ReactTestUtils.findRenderedComponentWithType(instance, MockedComponent));
-    assert.equal(hasScript(URL), true);
+    assert.equal(hasScript(URL), true, "Url in document");
+    assert.equal(asyncScriptOnLoadCalled, true, "asyncScriptOnLoad callback called");
+    assert.equal(scriptLoaded, true, "script loaded state set");
+    assert.equal(scriptErrored, undefined, "script errored state unset");
   });
-  it("should handle successfully already loaded global object", () => {
-    const URL = "http://example.com";
+
+  it("should fire asyncScriptOnLoad on errored script load", () => {
+    const URL = "http://example.com/?errored=true";
+    let asyncScriptOnLoadCalled = false;
+    let scriptErrored = false;
+    let scriptLoaded = false;
+    const asyncScriptOnLoadSpy = (entry) => {
+      scriptErrored = entry.errored;
+      scriptLoaded = entry.loaded;
+      asyncScriptOnLoadCalled = true;
+    }
+    const ComponentWrapper = makeAsyncScriptLoader(URL)(MockedComponent);
+    ReactTestUtils.renderIntoDocument(
+      <ComponentWrapper asyncScriptOnLoad={asyncScriptOnLoadSpy} />
+    );
+    documentErrorScript(URL);
+
+    assert.equal(hasScript(URL), true, "Url in document");
+    assert.equal(asyncScriptOnLoadCalled, true, "asyncScriptOnLoad callback called");
+    assert.equal(scriptErrored, true, "script errored state set");
+    assert.equal(scriptLoaded, false, "script loaded state set");
+  });
+
+  it("should handle successfully already loaded global object and fire asyncScriptOnLoad", () => {
+    const URL = "http://example.com/?global=true";
     const globalName = "SomeGlobal";
     window[globalName] = {};
+    let asyncScriptOnLoadCalled = false;
+    const asyncScriptOnLoadSpy = () => {
+      asyncScriptOnLoadCalled = true;
+    }
     const ComponentWrapper = makeAsyncScriptLoader(URL, { globalName: globalName })(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
-      <ComponentWrapper />
+      <ComponentWrapper asyncScriptOnLoad={asyncScriptOnLoadSpy} />
     );
-    assert.equal(hasScript(URL), true);
+
+    assert.equal(hasScript(URL), false, "Url not in document");
+    assert.equal(asyncScriptOnLoadCalled, true, "asyncScriptOnLoad callback called");
     ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance));
     instance.componentWillUnmount();
     delete window[globalName];
@@ -61,13 +115,14 @@ describe("AsyncScriptLoader", () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
     );
-    assert.equal(hasScript(URL), true);
+
+    assert.equal(hasScript(URL), true, "Url in document");
     ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance));
     instance.componentWillUnmount();
   });
 
   it("should expose functions with scope correctly", (done) => {
-    const ComponentWrapper = makeAsyncScriptLoader("http://example.com/", {
+    const ComponentWrapper = makeAsyncScriptLoader("http://example.com/?functions=true", {
       exposeFuncs: ["callsACallback"],
     })(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
@@ -75,26 +130,30 @@ describe("AsyncScriptLoader", () => {
     );
     instance.callsACallback(done);
   });
+
   it("should not remove tag script on removeOnUnmount option not set", () => {
     const URL = "http://example.com/?removeOnUnmount=notset";
     const ComponentWrapper = makeAsyncScriptLoader(URL)(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
     );
-    assert.equal(hasScript(URL), true);
-    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance));
-    instance.componentWillUnmount();
-    assert.equal(hasScript(URL), true);
+
+    assert.equal(hasScript(URL), true, "Url in document");
+    const unmounted = ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance).parentNode);
+    assert.equal(unmounted, true, "successfully unmounted");
+    assert.equal(hasScript(URL), true, "Url still in document after unmounting");
   });
+
   it("should remove tag script on removeOnUnmount option set to true", () => {
     const URL = "http://example.com/?removeOnUnmount=true";
     const ComponentWrapper = makeAsyncScriptLoader(URL, { removeOnUnmount: true })(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
     );
-    assert.equal(hasScript(URL), true);
-    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance));
-    instance.componentWillUnmount();
-    assert.equal(hasScript(URL), false);
+
+    assert.equal(hasScript(URL), true, "Url in document");
+    const unmounted = ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance).parentNode);
+    assert.equal(unmounted, true, "successfully unmounted");
+    assert.equal(hasScript(URL), false, "Url not in document after unmounting");
   });
 });

--- a/test/async-script-loader-spec.js
+++ b/test/async-script-loader-spec.js
@@ -31,7 +31,7 @@ describe("AsyncScriptLoader", () => {
 
   it("should return a component that contains the passed component", () => {
     const URL = "http://example.com";
-    const ComponentWrapper = makeAsyncScriptLoader(MockedComponent, URL);
+    const ComponentWrapper = makeAsyncScriptLoader(URL)(MockedComponent);
     assert.equal(ComponentWrapper.displayName, "AsyncScriptLoader(MockedComponent)");
     const instance = ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
@@ -45,7 +45,7 @@ describe("AsyncScriptLoader", () => {
     const URL = "http://example.com";
     const globalName = "SomeGlobal";
     window[globalName] = {};
-    const ComponentWrapper = makeAsyncScriptLoader(MockedComponent, URL, { globalName: globalName });
+    const ComponentWrapper = makeAsyncScriptLoader(URL, { globalName: globalName })(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
     );
@@ -57,7 +57,7 @@ describe("AsyncScriptLoader", () => {
 
   it("should accept a function for scriptURL", () => {
     const URL = "http://example.com/?url=function";
-    const ComponentWrapper = makeAsyncScriptLoader(MockedComponent, () => URL);
+    const ComponentWrapper = makeAsyncScriptLoader(() => URL)(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
     );
@@ -67,9 +67,9 @@ describe("AsyncScriptLoader", () => {
   });
 
   it("should expose functions with scope correctly", (done) => {
-    const ComponentWrapper = makeAsyncScriptLoader(MockedComponent, "http://example.com/", {
+    const ComponentWrapper = makeAsyncScriptLoader("http://example.com/", {
       exposeFuncs: ["callsACallback"],
-    });
+    })(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
     );
@@ -77,7 +77,7 @@ describe("AsyncScriptLoader", () => {
   });
   it("should not remove tag script on removeOnUnmount option not set", () => {
     const URL = "http://example.com/?removeOnUnmount=notset";
-    const ComponentWrapper = makeAsyncScriptLoader(MockedComponent, URL);
+    const ComponentWrapper = makeAsyncScriptLoader(URL)(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
     );
@@ -88,7 +88,7 @@ describe("AsyncScriptLoader", () => {
   });
   it("should remove tag script on removeOnUnmount option set to true", () => {
     const URL = "http://example.com/?removeOnUnmount=true";
-    const ComponentWrapper = makeAsyncScriptLoader(MockedComponent, URL, { removeOnUnmount: true });
+    const ComponentWrapper = makeAsyncScriptLoader(URL, { removeOnUnmount: true })(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
     );


### PR DESCRIPTION
"Step 1" of #33 
- implement basic HOC pattern
  - fix tests
- add tests for `asyncScriptOnLoad`
- add tests for `onload` and `onerror`
- pass script `entry` object to `asyncScriptOnLoad`
  - maybe remove `observers` key? just have `loaded`/`errored` and maybe add the `url`?

TODO:
- [x] update readme with changes

@dozoisch Let me know about the question above and if you have any other questions or updates.

also removed the old ie support check. it was actually broken anyway 😭 
`onreadystatechange` has the wrong reference for `this`:
```
script.onreadystatechange = () => {
  if (this.readyState === "loaded") {
```
should be:
```
script.onreadystatechange = () => {
  if (script.readyState === "loaded") {
```
reference: https://www.html5rocks.com/en/tutorials/speed/script-loading/

With `v1.0.0` release time to say goodbye to old ie`<10`?