### PR TITLE
Hoist non react statics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A React HOC for loading 3rd party scripts asynchronously. This HOC allows you to
 - `Component`: The *Component* to wrap.
 - `getScriptUrl`: *string* or *function* that returns the full URL of the script tag.
 - `options` *(optional)*:
-    - `exposeFuncs`: *array of strings* : It'll create a function that will call the child component with the same name. It passes arguments and return value.
     - `callbackName`: *string* : If the script needs to call a global function when finished loading *(for example: `recaptcha/api.js?onload=callbackName`)*. Please provide the callback name here and it will be autoregistered on `window` for you.
     - `globalName`: *string* : If wanted, provide the globalName of the loaded script. It'll be injected on the component with the same name *(ex: "grecaptcha")*
     - `removeOnUnmount`: *boolean* **default=false** : If set to `true` removes the script tag on the component unmount
@@ -71,38 +70,6 @@ React.render(
   <ReCAPTCHAWrapper asyncScriptOnLoad={onLoad} {...reCAPTCHAprops} />,
   document.body
 );
-```
-
-## Expose Functions
-
-This is really useful if the child component has some utility functions (like `getValue`) that you would like the wrapper to expose.
-
-You can still retrieve the child component using `getComponent()`.
-
-### Example
-
-```js
-class MockedComponent extends React.Component {
-
-  callsACallback(fn) {
-    fn();
-  },
-
-  render() {
-    return <span/>;
-  }
-};
-MockedComponent.displayName = "MockedComponent";
-
-let ComponentWrapper = makeAsyncScriptLoader("http://example.com", {
-  exposeFuncs: ["callsACallback"]
-})(MockedComponent);
-
-const instance = ReactTestUtils.renderIntoDocument(
-  <ComponentWrapper />
-);
-
-instance.callsACallback(function () { console.log("Called from child", this.constructor.displayName); });
 ```
 
 ## Notes

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-runtime": "^6.0.0",
     "chai": "^3.5.0",
     "es5-shim": "~4.1.3",
+    "es6-shim": "^0.35.3",
     "eslint": "~1.6.0",
     "eslint-config-defaults": "~7.0.1",
     "eslint-plugin-react": "~3.5.1",
@@ -51,7 +52,7 @@
     "karma-sourcemap-loader": "~0.3.5",
     "karma-webpack": "~1.7.0",
     "mocha": "~2.3.3",
-    "phantomjs": "^1.9.18",
+    "phantomjs": "^2.0.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "webpack": "~1.14.0"

--- a/package.json
+++ b/package.json
@@ -52,14 +52,15 @@
     "karma-webpack": "~1.7.0",
     "mocha": "~2.3.3",
     "phantomjs": "^1.9.18",
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2",
     "webpack": "~1.14.0"
   },
   "peerDependencies": {
     "react": ">=15.5.0"
   },
   "dependencies": {
+    "hoist-non-react-statics": "^3.0.1",
     "prop-types": ">=15.5.0"
   }
 }

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -1,5 +1,6 @@
 import { Component, createElement } from "react";
 import PropTypes from "prop-types";
+import hoistStatics from "hoist-non-react-statics";
 
 let SCRIPT_MAP = {};
 
@@ -186,13 +187,6 @@ export default function makeAsyncScript(getScriptURL, options) {
       asyncScriptOnLoad: PropTypes.func,
     };
 
-    if (options.exposeFuncs) {
-      options.exposeFuncs.forEach(funcToExpose => {
-        AsyncScriptLoader.prototype[funcToExpose] = function() {
-          return this.getComponent()[funcToExpose](...arguments);
-        };
-      });
-    }
-    return AsyncScriptLoader;
+    return hoistStatics(AsyncScriptLoader, WrappedComponent);
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
 import "es5-shim";
+import "es6-shim";
 const testsContext = require.context(".", true, /-spec$/);
 testsContext.keys().forEach(testsContext);


### PR DESCRIPTION
- depends on #34 
- adds `hoist-non-react-statics`
- removes `exposeFuncs`
  - can still access via `getComponent`
  - added test for `getComponent`

dev:
- updated `phantomJS`
- added `es6-shim` for tests