### PR TITLE
React forward ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "phantomjs": "^2.0.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
+    "react-is": "^16.4.2",
     "webpack": "~1.14.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "webpack": "~1.14.0"
   },
   "peerDependencies": {
-    "react": ">=15.5.0"
+    "react": ">=16.3.0"
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.0.1",
-    "prop-types": ">=15.5.0"
+    "prop-types": "^15.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "webpack": "~1.14.0"
   },
   "peerDependencies": {
-    "react": ">=16.3.0"
+    "react": ">=16.4.1"
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.0.1",

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -187,8 +187,6 @@ export default function makeAsyncScript(getScriptURL, options) {
       asyncScriptOnLoad: PropTypes.func,
     };
 
-    hoistStatics(ForwardedComponent, WrappedComponent);
-
-    return ForwardedComponent;
+    return hoistStatics(ForwardedComponent, WrappedComponent);
   }
 }

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -174,13 +174,11 @@ export default function makeAsyncScript(getScriptURL, options) {
       }
     }
 
-    hoistStatics(AsyncScriptLoader, WrappedComponent);
-
     // Note the second param "ref" provided by React.forwardRef.
-    // We can pass it along to HoistedAsyncScriptLoader as a regular prop, e.g. "forwardedRef"
+    // We can pass it along to AsyncScriptLoader as a regular prop, e.g. "forwardedRef"
     // And it can then be attached to the Component.
     const ForwardedComponent = forwardRef((props, ref) => {
-      return createElement(AsyncScriptLoader, Object.assign({}, props, { forwardedRef: ref }));
+      return createElement(AsyncScriptLoader, {...props, forwardedRef: ref });
     });
     ForwardedComponent.displayName = `AsyncScriptLoader(${wrappedComponentName})`;
     ForwardedComponent.propTypes = {

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -1,4 +1,4 @@
-import { Component, createElement } from "react";
+import { Component, createElement, forwardRef } from "react";
 import PropTypes from "prop-types";
 import hoistStatics from "hoist-non-react-statics";
 
@@ -11,14 +11,13 @@ export default function makeAsyncScript(getScriptURL, options) {
   options = options || {};
   return function wrapWithAsyncScript(WrappedComponent) {
     const wrappedComponentName =
-    WrappedComponent.displayName || WrappedComponent.name || "Component";
+      WrappedComponent.displayName || WrappedComponent.name || "Component";
 
     class AsyncScriptLoader extends Component {
       constructor(props, context) {
         super(props, context)
         this.state = {};
         this.__scriptURL = "";
-        this.assignChildComponent = this.assignChildComponent.bind(this);
       }
 
       asyncScriptLoaderGetScriptLoaderID() {
@@ -32,14 +31,6 @@ export default function makeAsyncScript(getScriptURL, options) {
         this.__scriptURL =
           typeof getScriptURL === "function" ? getScriptURL() : getScriptURL;
         return this.__scriptURL;
-      }
-
-      assignChildComponent(ref) {
-        this.__childComponent = ref;
-      }
-
-      getComponent() {
-        return this.__childComponent;
       }
 
       asyncScriptLoaderHandleLoad(state) {
@@ -171,22 +162,33 @@ export default function makeAsyncScript(getScriptURL, options) {
       render() {
         const globalName = options.globalName;
         // remove asyncScriptOnLoad from childProps
-        let { asyncScriptOnLoad, ...childProps } = this.props; // eslint-disable-line no-unused-vars
+        let { asyncScriptOnLoad, forwardedRef, ...childProps } = this.props; // eslint-disable-line no-unused-vars
         if (globalName && typeof window !== "undefined") {
           childProps[globalName] =
             typeof window[globalName] !== "undefined"
               ? window[globalName]
               : undefined;
         }
-        childProps.ref = this.assignChildComponent;
+        childProps.ref = forwardedRef;
         return createElement(WrappedComponent, childProps);
       }
     }
-    AsyncScriptLoader.displayName = `AsyncScriptLoader(${wrappedComponentName})`;
-    AsyncScriptLoader.propTypes = {
+
+    hoistStatics(AsyncScriptLoader, WrappedComponent);
+
+    // Note the second param "ref" provided by React.forwardRef.
+    // We can pass it along to HoistedAsyncScriptLoader as a regular prop, e.g. "forwardedRef"
+    // And it can then be attached to the Component.
+    const ForwardedComponent = forwardRef((props, ref) => {
+      return createElement(AsyncScriptLoader, Object.assign({}, props, { forwardedRef: ref }));
+    });
+    ForwardedComponent.displayName = `AsyncScriptLoader(${wrappedComponentName})`;
+    ForwardedComponent.propTypes = {
       asyncScriptOnLoad: PropTypes.func,
     };
 
-    return hoistStatics(AsyncScriptLoader, WrappedComponent);
+    hoistStatics(ForwardedComponent, WrappedComponent);
+
+    return ForwardedComponent;
   }
 }

--- a/test/async-script-loader-spec.js
+++ b/test/async-script-loader-spec.js
@@ -55,6 +55,7 @@ describe("AsyncScriptLoader", () => {
     documentLoadScript(URL);
 
     assert.equal(ReactIs.isValidElementType(ComponentWrapper), true, "is valid elemnt type");
+    assert.equal(ReactIs.isForwardRef(<ComponentWrapper />), true, "is valid forwardRef");
     assert.equal(hasScript(URL), true, "Url in document");
     assert.equal(asyncScriptOnLoadCalled, true, "asyncScriptOnLoad callback called");
     assert.equal(scriptLoaded, true, "script loaded state set");

--- a/test/async-script-loader-spec.js
+++ b/test/async-script-loader-spec.js
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import ReactTestUtils from "react-dom/test-utils";
+import * as ReactIs from "react-is";
 import makeAsyncScriptLoader from "../src/async-script-loader";
 
 class MockedComponent extends React.Component {
@@ -48,14 +49,12 @@ describe("AsyncScriptLoader", () => {
     }
     const ComponentWrapper = makeAsyncScriptLoader(URL)(MockedComponent);
     assert.equal(ComponentWrapper.displayName, "AsyncScriptLoader(MockedComponent)");
-    const instance = ReactTestUtils.renderIntoDocument(
+    ReactTestUtils.renderIntoDocument(
       <ComponentWrapper asyncScriptOnLoad={asyncScriptOnLoadSpy} />
     );
     documentLoadScript(URL);
 
-    // assert.ok(ReactTestUtils.isCompositeComponent(instance));
-    // assert.ok(ReactTestUtils.isCompositeComponentWithType(instance, ComponentWrapper));
-    // assert.isNotNull(ReactTestUtils.findRenderedComponentWithType(instance, MockedComponent));
+    assert.equal(ReactIs.isValidElementType(ComponentWrapper), true, "is valid elemnt type");
     assert.equal(hasScript(URL), true, "Url in document");
     assert.equal(asyncScriptOnLoadCalled, true, "asyncScriptOnLoad callback called");
     assert.equal(scriptLoaded, true, "script loaded state set");

--- a/test/async-script-loader-spec.js
+++ b/test/async-script-loader-spec.js
@@ -57,9 +57,9 @@ describe("AsyncScriptLoader", () => {
     );
     documentLoadScript(URL);
 
-    assert.ok(ReactTestUtils.isCompositeComponent(instance));
-    assert.ok(ReactTestUtils.isCompositeComponentWithType(instance, ComponentWrapper));
-    assert.isNotNull(ReactTestUtils.findRenderedComponentWithType(instance, MockedComponent));
+    // assert.ok(ReactTestUtils.isCompositeComponent(instance));
+    // assert.ok(ReactTestUtils.isCompositeComponentWithType(instance, ComponentWrapper));
+    // assert.isNotNull(ReactTestUtils.findRenderedComponentWithType(instance, MockedComponent));
     assert.equal(hasScript(URL), true, "Url in document");
     assert.equal(asyncScriptOnLoadCalled, true, "asyncScriptOnLoad callback called");
     assert.equal(scriptLoaded, true, "script loaded state set");
@@ -97,27 +97,23 @@ describe("AsyncScriptLoader", () => {
       asyncScriptOnLoadCalled = true;
     }
     const ComponentWrapper = makeAsyncScriptLoader(URL, { globalName: globalName })(MockedComponent);
-    const instance = ReactTestUtils.renderIntoDocument(
+    ReactTestUtils.renderIntoDocument(
       <ComponentWrapper asyncScriptOnLoad={asyncScriptOnLoadSpy} />
     );
 
     assert.equal(hasScript(URL), false, "Url not in document");
     assert.equal(asyncScriptOnLoadCalled, true, "asyncScriptOnLoad callback called");
-    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance));
-    instance.componentWillUnmount();
     delete window[globalName];
   });
 
   it("should accept a function for scriptURL", () => {
     const URL = "http://example.com/?url=function";
     const ComponentWrapper = makeAsyncScriptLoader(() => URL)(MockedComponent);
-    const instance = ReactTestUtils.renderIntoDocument(
+    ReactTestUtils.renderIntoDocument(
       <ComponentWrapper />
     );
 
     assert.equal(hasScript(URL), true, "Url in document");
-    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(instance));
-    instance.componentWillUnmount();
   });
 
   it("should expose statics", (done) => {
@@ -130,7 +126,9 @@ describe("AsyncScriptLoader", () => {
     const URL = "http://example.com/?removeOnUnmount=notset";
     const ComponentWrapper = makeAsyncScriptLoader(URL)(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
-      <ComponentWrapper />
+      <div>
+        <ComponentWrapper />
+      </div>
     );
 
     assert.equal(hasScript(URL), true, "Url in document");
@@ -143,7 +141,9 @@ describe("AsyncScriptLoader", () => {
     const URL = "http://example.com/?removeOnUnmount=true";
     const ComponentWrapper = makeAsyncScriptLoader(URL, { removeOnUnmount: true })(MockedComponent);
     const instance = ReactTestUtils.renderIntoDocument(
-      <ComponentWrapper />
+      <div>
+        <ComponentWrapper />
+      </div>
     );
 
     assert.equal(hasScript(URL), true, "Url in document");
@@ -152,7 +152,7 @@ describe("AsyncScriptLoader", () => {
     assert.equal(hasScript(URL), false, "Url not in document after unmounting");
   });
 
-  it("should allow you to access methods on the wrappedComponent via getComponent", (done) => {
+  it.skip("should allow you to access methods on the wrappedComponent via getComponent", (done) => {
     class MockedComponentMethod extends React.Component {
       callsACallback(fn) {
         assert.equal(this.constructor.name, "MockedComponentMethod");
@@ -163,7 +163,9 @@ describe("AsyncScriptLoader", () => {
     const URL = "http://example.com/?getComponent=true";
     const ComponentWrapper = makeAsyncScriptLoader(URL)(MockedComponentMethod);
     const instance = ReactTestUtils.renderIntoDocument(
-      <ComponentWrapper />
+      <div>
+        <ComponentWrapper />
+      </div>
     );
     const wrappedComponent = instance.getComponent();
 


### PR DESCRIPTION
- add `forwardRef`
- remove `getComponent`

TODO:
- [x] fix tests
  - [x] add test that uses refs
- [x] update docs


 i'd like to get a v`1.0.0-rc1` release candidate out there soonish so i can start using in codesandbox and maybe get a `react-google-recaptcha` release candidate v`1.0.0` out using this release candidate 😸 