### PR TITLE
Support for adding a script id attribute

### DIFF
--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -57,7 +57,7 @@ export default function makeAsyncScript(getScriptURL, options) {
       componentDidMount() {
         const scriptURL = this.setupScriptURL();
         const key = this.asyncScriptLoaderGetScriptLoaderID();
-        const { globalName, callbackName } = options;
+        const { globalName, callbackName, scriptId } = options;
 
         // check if global object already attached to window
         if (globalName && typeof window[globalName] !== "undefined") {
@@ -94,6 +94,9 @@ export default function makeAsyncScript(getScriptURL, options) {
 
         script.src = scriptURL;
         script.async = true;
+        if (scriptId) {
+          script.id = scriptId;
+        }
 
         let callObserverFuncAndRemoveObserver = func => {
           if (SCRIPT_MAP[scriptURL]) {


### PR DESCRIPTION
Not sure if you're interested in this change, but here's the use case I've encountered.

When trying to wrap a particular chat widget library, I found out the vendor's resulting js that is loaded via the script tag has logic that tries to do a lookup of that same script tag in the dom by using an `id`. I don't have a clue as to why, but the chat widget doesn't work if that fails.

I can't think of other attributes to add, so I didn't make it generic to take an Object mapping attribute names to values.