### PR TITLE
Treat callback and onLoad equally for script load verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-async-script",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A composition mixin for loading scripts asynchronously for React",
   "main": "lib/async-script-loader.js",
   "module": "lib/esm/async-script-loader.js",

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -45,13 +45,29 @@ export default function makeAsyncScript(getScriptURL, options) {
 
       asyncScriptLoaderTriggerOnScriptLoaded() {
         let mapEntry = SCRIPT_MAP[this.__scriptURL];
-        if (!mapEntry || !mapEntry.loaded) {
+        if (!mapEntry) {
           throw new Error("Script is not loaded.");
         }
-        for (let obsKey in mapEntry.observers) {
-          mapEntry.observers[obsKey](mapEntry);
+        if (!mapEntry.loaded) {
+          mapEntry.loaded = true;
         }
+        this.callObserverFuncAndRemoveObserver(mapEntry, observer => {
+          observer(mapEntry);
+          return true;
+        });
         delete window[options.callbackName];
+      }
+
+      callObserverFuncAndRemoveObserver(mapEntry, func) {
+        if (mapEntry) {
+          let observersMap = mapEntry.observers;
+
+          for (let obsKey in observersMap) {
+            if (func(observersMap[obsKey])) {
+              delete observersMap[obsKey];
+            }
+          }
+        }
       }
 
       componentDidMount() {
@@ -98,19 +114,6 @@ export default function makeAsyncScript(getScriptURL, options) {
           script.id = scriptId;
         }
 
-        let callObserverFuncAndRemoveObserver = func => {
-          if (SCRIPT_MAP[scriptURL]) {
-            let mapEntry = SCRIPT_MAP[scriptURL];
-            let observersMap = mapEntry.observers;
-
-            for (let obsKey in observersMap) {
-              if (func(observersMap[obsKey])) {
-                delete observersMap[obsKey];
-              }
-            }
-          }
-        };
-
         if (callbackName && typeof window !== "undefined") {
           window[callbackName] = () =>
             this.asyncScriptLoaderTriggerOnScriptLoaded();
@@ -119,11 +122,11 @@ export default function makeAsyncScript(getScriptURL, options) {
         script.onload = () => {
           let mapEntry = SCRIPT_MAP[scriptURL];
           if (mapEntry) {
+            if (mapEntry.loaded) {
+              return;
+            }
             mapEntry.loaded = true;
-            callObserverFuncAndRemoveObserver(observer => {
-              if (callbackName) {
-                return false;
-              }
+            this.callObserverFuncAndRemoveObserver(mapEntry, observer => {
               observer(mapEntry);
               return true;
             });
@@ -133,7 +136,7 @@ export default function makeAsyncScript(getScriptURL, options) {
           let mapEntry = SCRIPT_MAP[scriptURL];
           if (mapEntry) {
             mapEntry.errored = true;
-            callObserverFuncAndRemoveObserver(observer => {
+            this.callObserverFuncAndRemoveObserver(mapEntry, observer => {
               observer(mapEntry);
               return true;
             });

--- a/test/async-script-loader-spec.js
+++ b/test/async-script-loader-spec.js
@@ -256,26 +256,26 @@ describe("AsyncScriptLoader", () => {
   });
 
   it("should expose global callback", () => {
-    const callbackName = 'exampleCallback';
+    const callbackName = "exampleCallback";
     const URL = `http://example.com/?callback=${callbackName}`;
+    // eslint-disable-next-line no-unused-vars
     const ComponentWrapper = makeAsyncScriptLoader(URL, {
       callbackName
     })(MockedComponent);
-    ReactTestUtils.renderIntoDocument(
-      <ComponentWrapper />
-    );
+    ReactTestUtils.renderIntoDocument(<ComponentWrapper />);
 
-    expect(typeof window[callbackName]).toBe('function');
+    expect(typeof window[callbackName]).toBe("function");
     delete window[callbackName];
-  })
+  });
 
   it("should call loaded if global callback called before onLoad", () => {
-    const callbackName = 'exampleCallbackBeforeOnload';
+    const callbackName = "exampleCallbackBeforeOnload";
     const URL = `http://example.com/?callback=${callbackName}`;
     let asyncScriptOnLoadCalled = false;
     const asyncScriptOnLoadSpy = () => {
       asyncScriptOnLoadCalled = true;
     };
+    // eslint-disable-next-line no-unused-vars
     const ComponentWrapper = makeAsyncScriptLoader(URL, {
       callbackName
     })(MockedComponent);
@@ -286,10 +286,10 @@ describe("AsyncScriptLoader", () => {
     window[callbackName]();
     expect(asyncScriptOnLoadCalled).toEqual(true);
     delete window[callbackName];
-  })
+  });
 
   it("should call loaded only once if global callback then onload", () => {
-    const callbackName = 'exampleCallbackThenOnload';
+    const callbackName = "exampleCallbackThenOnload";
     const URL = `http://example.com/?callback=${callbackName}`;
     let asyncScriptOnLoadCalled = false;
     let callCount = 0;
@@ -297,6 +297,7 @@ describe("AsyncScriptLoader", () => {
       asyncScriptOnLoadCalled = true;
       callCount++;
     };
+    // eslint-disable-next-line no-unused-vars
     const ComponentWrapper = makeAsyncScriptLoader(URL, {
       callbackName
     })(MockedComponent);
@@ -309,10 +310,10 @@ describe("AsyncScriptLoader", () => {
     documentLoadScript(URL);
     expect(callCount).toEqual(1);
     delete window[callbackName];
-  })
+  });
 
   it("should call loaded only once if onload then global callback", () => {
-    const callbackName = 'exampleOnloadThenCallback';
+    const callbackName = "exampleOnloadThenCallback";
     const URL = `http://example.com/?callback=${callbackName}`;
     let asyncScriptOnLoadCalled = false;
     let callCount = 0;
@@ -320,6 +321,7 @@ describe("AsyncScriptLoader", () => {
       asyncScriptOnLoadCalled = true;
       callCount++;
     };
+    // eslint-disable-next-line no-unused-vars
     const ComponentWrapper = makeAsyncScriptLoader(URL, {
       callbackName
     })(MockedComponent);
@@ -332,5 +334,5 @@ describe("AsyncScriptLoader", () => {
     window[callbackName]();
     expect(callCount).toEqual(1);
     delete window[callbackName];
-  })
+  });
 });

--- a/test/async-script-loader-spec.js
+++ b/test/async-script-loader-spec.js
@@ -254,4 +254,19 @@ describe("AsyncScriptLoader", () => {
     expect(instance._internalRef.current.internalCallsACallback).toBeTruthy();
     instance._internalRef.current.internalCallsACallback(done);
   });
+
+  it("should expose global callback", () => {
+    const callbackName = 'exampleCallback';
+    const URL = `http://example.com/?callback=${callbackName}`;
+    // eslint-disable-next-line no-unused-vars
+    const ComponentWrapper = makeAsyncScriptLoader(URL, {
+      callbackName
+    })(MockedComponent);
+    ReactTestUtils.renderIntoDocument(
+      <ComponentWrapper />
+    );
+
+    expect(typeof window[callbackName]).toBe('function');
+    delete window[callbackName];
+  })
 });


### PR DESCRIPTION
This fixes the problem in #6.

It treats both callback and onLoad equally in that if either one of them is called first it presumes that the script is fully loaded. Any subsequent calls from either onLoad or callback are ignored.