### PR TITLE
#51 added support for optional attributes that can be added to the generated script tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A React HOC for loading 3rd party scripts asynchronously. This HOC allows you to
 - `Component`: The *Component* to wrap.
 - `getScriptUrl`: *string* or *function* that returns the full URL of the script tag.
 - `options` *(optional)*:
+    - `attributes`: *object* : If the script needs attributes (such as `data-` attributes), then provide them as key/value pairs of strings and they will be added to the generated script tag.
     - `callbackName`: *string* : If the script needs to call a global function when finished loading *(for example: `recaptcha/api.js?onload=callbackName`)*. Please provide the callback name here and it will be autoregistered on `window` for you.
     - `globalName`: *string* : Can provide the name of the global that the script attaches to `window`. Async-script will pass this as a prop to the wrapped component. *(`props[globalName] = window[globalName]`)*
     - `removeOnUnmount`: *boolean* **default=false** : If set to `true` removes the script tag when component unmounts.

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -94,6 +94,11 @@ export default function makeAsyncScript(getScriptURL, options) {
 
         script.src = scriptURL;
         script.async = true;
+
+        for (let attribute in options.attributes) {
+          script.setAttribute( attribute, options.attributes[attribute] )
+        }
+
         if (scriptId) {
           script.id = scriptId;
         }

--- a/src/async-script-loader.js
+++ b/src/async-script-loader.js
@@ -96,7 +96,7 @@ export default function makeAsyncScript(getScriptURL, options) {
         script.async = true;
 
         for (let attribute in options.attributes) {
-          script.setAttribute( attribute, options.attributes[attribute] )
+          script.setAttribute(attribute, options.attributes[attribute]);
         }
 
         if (scriptId) {

--- a/test/async-script-loader-spec.js
+++ b/test/async-script-loader-spec.js
@@ -133,6 +133,22 @@ describe("AsyncScriptLoader", () => {
     expect(script.id).toEqual(scriptId);
   });
 
+  it("should add attributes to the script tag", () => {
+    const URL = "http://example.com/?has_attributes=true";
+    const attributes = { "data-foo": "bar", foo2: "bar2" };
+
+    // eslint-disable-next-line no-unused-vars
+    const ComponentWrapper = makeAsyncScriptLoader(URL, { attributes })(
+      MockedComponent
+    );
+    ReactTestUtils.renderIntoDocument(<ComponentWrapper />);
+
+    expect(hasScript(URL)).toEqual(true);
+    const script = getScript(URL);
+    expect(script.getAttribute("data-foo")).toEqual("bar");
+    expect(script.getAttribute("foo2")).toEqual("bar2");
+  });
+
   it("should expose statics", done => {
     class MockedComponentWithStatic extends React.Component {
       static callsACallback(fn) {


### PR DESCRIPTION
This is a PR for feature request #51. 

It adds support for optionally adding attributes to the script tag. 